### PR TITLE
[en] Make timers more precise (for cooking)

### DIFF
--- a/speech_to_phrase/sentences/en.yaml
+++ b/speech_to_phrase/sentences/en.yaml
@@ -28,16 +28,14 @@ lists:
   minutes_small:
     range:
       from: 2
-      to: 9
+      to: 19
   minutes_large:
     range:
-      from: 10
+      from: 20
       to: 100
       step: 10
   minutes_extra:
     values:
-      - in: fifteen
-        out: 15
       - in: forty five
         out: 45
   minutes_half:


### PR DESCRIPTION
When cooking you sometimes need precise timers longer than 10 minutes.
For example, some types of pasta need to cook for 12 minutes.
To be on the safe side (in case there are other culinary dishes requiring precise timing), I've increased minutes_small to 20.