### PR TITLE
Add supported features to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.4.0 (unreleased)
+
+- Add supported features to `light`, `fan`, `cover`, and `media_player` domains (used in `requires_context`)
+    - `light_supports_color` (color mode is hs/rgb/rgbw/rgbww/xy)
+    - `light_supports_brightness` (color mode is hs/rgb/rgbw/rgbww/xy/brightness/white)
+    - `fan_supports_speed` - fan has `SET_SPEED` feature
+    - `cover_supports_position` - cover has `SET_POSITION` feature
+    - `media_player_supports_pause` - media player has `PAUSE` feature
+    - `media_player_supports_volume_set` - media player has `VOLUME_SET` feature
+    - `media_player_supports_next_track` - media player has `NEXT_TRACK` feature
+- Change timer minutes to 1-20
+
 ## 1.3.0
 
 - Add Coqui STT

--- a/tests/test_hass_api.py
+++ b/tests/test_hass_api.py
@@ -1,6 +1,76 @@
 """Tests for Home Assistant API."""
 
-from speech_to_phrase.hass_api import Entity, Things
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from speech_to_phrase.hass_api import Entity, Things, get_hass_info
+
+
+class MockWebsocket:
+    """Mock websocket responses from Home Assistant server."""
+
+    def __init__(
+        self,
+        responses: List[
+            Union[
+                Tuple[Optional[str], Dict[str, Any]],
+                Tuple[Optional[str], Dict[str, Any], Dict[str, Any]],
+            ]
+        ],
+    ) -> None:
+        # list of (type, response) tuples
+        self.responses = responses
+
+        self._next_msg: Optional[Dict[str, Any]] = None
+
+    async def receive_json(self) -> Dict[str, Any]:
+        """Get next response message."""
+        assert self.responses
+
+        response = self.responses[0]
+        expected_msg: Optional[Dict[str, Any]] = None
+
+        if len(response) == 3:
+            response_type, response_data, expected_msg = response
+        else:
+            response_type, response_data = response
+
+        if response_type:
+            assert self._next_msg
+            assert response_type == self._next_msg["type"]
+
+        if expected_msg:
+            assert self._next_msg
+            for key, value in expected_msg.items():
+                assert key in self._next_msg
+                assert self._next_msg[key] == value
+
+        self.responses = self.responses[1:]
+        self._next_msg = None
+
+        response_data["success"] = True
+        return response_data
+
+    async def send_json(self, msg):
+        """Set type of next command."""
+        self._next_msg = msg
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+def _make_session(mock_websocket: MockWebsocket) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.ws_connect = MagicMock(return_value=mock_websocket)
+
+    return mock_session
 
 
 def test_template_syntax_removed() -> None:
@@ -25,3 +95,280 @@ def test_template_syntax_removed() -> None:
             ]
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_system_and_pipeline_languages() -> None:
+    """Test retrieval of HA system language and pipeline STT languages."""
+    mock_websocket = MockWebsocket(
+        [
+            (None, {"type": "auth_required"}),
+            ("auth", {"type": "auth_ok"}),
+            ("get_config", {"result": {"language": "en"}}),
+            (
+                "assist_pipeline/pipeline/list",
+                {
+                    "result": {
+                        "pipelines": [{"stt_language": "de"}, {"stt_language": "nl"}]
+                    }
+                },
+            ),
+            (
+                "homeassistant/expose_entity/list",
+                {"result": {"exposed_entities": {}}},
+            ),
+            ("get_states", {"result": []}),
+            ("config/floor_registry/list", {"result": []}),
+            ("config/area_registry/list", {"result": []}),
+            ("config/entity_registry/get_entries", {"result": {}}),
+            (
+                "conversation/sentences/list",
+                {"result": {"trigger_sentences": []}},
+            ),
+        ]
+    )
+
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_websocket)):
+        ha_info = await get_hass_info("<token>", "<url>")
+        assert ha_info.system_language == "en"
+        assert ha_info.pipeline_languages == {"de", "nl"}
+
+
+@pytest.mark.asyncio
+async def test_unexposed_and_disabled_entities() -> None:
+    """Test that unexposed and disabled entities are skipped."""
+    mock_websocket = MockWebsocket(
+        [
+            (None, {"type": "auth_required"}),
+            ("auth", {"type": "auth_ok"}),
+            ("get_config", {"result": {"language": "en"}}),
+            (
+                "assist_pipeline/pipeline/list",
+                {"result": {"pipelines": []}},
+            ),
+            (
+                "homeassistant/expose_entity/list",
+                {
+                    "result": {
+                        "exposed_entities": {
+                            "light.unexposed_light": {"conversation": False},
+                            "light.disabled_light": {"conversation": True},
+                        }
+                    }
+                },
+            ),
+            (
+                "get_states",
+                {
+                    "result": [
+                        {"entity_id": "light.unexposed_light"},
+                        {
+                            "entity_id": "light.disabled_light",
+                        },
+                    ]
+                },
+            ),
+            ("config/floor_registry/list", {"result": []}),
+            ("config/area_registry/list", {"result": []}),
+            (
+                "config/entity_registry/get_entries",
+                {
+                    "result": {
+                        "light.disabled_light": {
+                            "name": "Disabled Light",
+                            "disabled_by": {},
+                        },
+                    }
+                },
+                {"entity_ids": ["light.disabled_light"]},
+            ),
+            (
+                "conversation/sentences/list",
+                {"result": {"trigger_sentences": []}},
+            ),
+        ]
+    )
+
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_websocket)):
+        ha_info = await get_hass_info("<token>", "<url>")
+        assert not ha_info.things.entities
+
+
+@pytest.mark.asyncio
+async def test_areas_and_floors() -> None:
+    """Test retrieval of areas and floors."""
+    mock_websocket = MockWebsocket(
+        [
+            (None, {"type": "auth_required"}),
+            ("auth", {"type": "auth_ok"}),
+            ("get_config", {"result": {"language": "en"}}),
+            (
+                "assist_pipeline/pipeline/list",
+                {"result": {"pipelines": []}},
+            ),
+            ("homeassistant/expose_entity/list", {"result": {"exposed_entities": {}}}),
+            ("get_states", {"result": []}),
+            (
+                "config/floor_registry/list",
+                {
+                    "result": [
+                        {
+                            "floor_id": "floor_1",
+                            "name": "Floor 1",
+                            "aliases": ["Floor One"],
+                        }
+                    ]
+                },
+            ),
+            (
+                "config/area_registry/list",
+                {
+                    "result": [
+                        {"area_id": "area_1", "name": "Area 1", "aliases": ["Area One"]}
+                    ]
+                },
+            ),
+            ("config/entity_registry/get_entries", {"result": {}}),
+            (
+                "conversation/sentences/list",
+                {"result": {"trigger_sentences": []}},
+            ),
+        ]
+    )
+
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_websocket)):
+        ha_info = await get_hass_info("<token>", "<url>")
+        assert len(ha_info.things.areas) == 1
+        area = ha_info.things.areas[0]
+        assert area.names == ["Area 1", "Area One"]
+
+        assert len(ha_info.things.floors) == 1
+        floor = ha_info.things.floors[0]
+        assert floor.names == ["Floor 1", "Floor One"]
+
+
+@pytest.mark.asyncio
+async def test_entity_names() -> None:
+    """Test retrieval of entity names."""
+    mock_websocket = MockWebsocket(
+        [
+            (None, {"type": "auth_required"}),
+            ("auth", {"type": "auth_ok"}),
+            ("get_config", {"result": {"language": "en"}}),
+            (
+                "assist_pipeline/pipeline/list",
+                {"result": {"pipelines": []}},
+            ),
+            (
+                "homeassistant/expose_entity/list",
+                {
+                    "result": {
+                        "exposed_entities": {
+                            "light.friendly_name": {"conversation": True},
+                            "light.registry_name": {"conversation": True},
+                            "light.original_name": {"conversation": True},
+                        }
+                    }
+                },
+            ),
+            (
+                "get_states",
+                {
+                    "result": [
+                        {
+                            "entity_id": "light.friendly_name",
+                            "attributes": {"friendly_name": "Friendly Name"},
+                        }
+                    ]
+                },
+            ),
+            ("config/floor_registry/list", {"result": []}),
+            ("config/area_registry/list", {"result": []}),
+            (
+                "config/entity_registry/get_entries",
+                {
+                    "result": {
+                        "light.friendly_name": {},
+                        "light.registry_name": {"name": "Registry Name"},
+                        "light.original_name": {"original_name": "Original Name"},
+                    }
+                },
+            ),
+            (
+                "conversation/sentences/list",
+                {"result": {"trigger_sentences": []}},
+            ),
+        ]
+    )
+
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_websocket)):
+        ha_info = await get_hass_info("<token>", "<url>")
+        assert len(ha_info.things.entities) == 3
+
+        names: Set[str] = set()
+        for entity in ha_info.things.entities:
+            assert entity.domain == "light"
+            assert len(entity.names) == 1
+            names.add(entity.names[0])
+
+        assert names == {"Friendly Name", "Registry Name", "Original Name"}
+
+
+@pytest.mark.asyncio
+async def test_light_features() -> None:
+    """Test that light entities report supported features."""
+    mock_websocket = MockWebsocket(
+        [
+            (None, {"type": "auth_required"}),
+            ("auth", {"type": "auth_ok"}),
+            ("get_config", {"result": {"language": "en"}}),
+            (
+                "assist_pipeline/pipeline/list",
+                {"result": {"pipelines": [{"stt_language": "de"}]}},
+            ),
+            (
+                "homeassistant/expose_entity/list",
+                {
+                    "result": {
+                        "exposed_entities": {"light.rgb_light": {"conversation": True}}
+                    }
+                },
+            ),
+            (
+                "get_states",
+                {
+                    "result": [
+                        {
+                            "entity_id": "light.rgb_light",
+                            "attributes": {
+                                "friendly_name": "RGB Light",
+                                "supported_color_modes": ["rgb"],
+                            },
+                        }
+                    ]
+                },
+            ),
+            (
+                "config/floor_registry/list",
+                {"result": [{"floor_id": "main_floor", "name": "Main"}]},
+            ),
+            (
+                "config/area_registry/list",
+                {"result": [{"area_id": "office_area", "name": "Office"}]},
+            ),
+            ("config/entity_registry/get_entries", {"result": {"light.rgb_light": {}}}),
+            (
+                "conversation/sentences/list",
+                {"result": {"trigger_sentences": []}},
+            ),
+        ]
+    )
+
+    with patch("aiohttp.ClientSession", return_value=_make_session(mock_websocket)):
+        ha_info = await get_hass_info("<token>", "<url>")
+        assert len(ha_info.things.entities) == 1
+
+        rgb_light = ha_info.things.entities[0]
+        assert rgb_light.domain == "light"
+        assert rgb_light.light_supports_color
+        assert rgb_light.light_supports_brightness


### PR DESCRIPTION
A set of boolean flags are automatically added to entities for specific domains that indicate if they support certain features. These flags can be used in `requires_context` to refine sentence generation.

- `light_supports_color` (color mode is hs/rgb/rgbw/rgbww/xy)
- `light_supports_brightness` (color mode is hs/rgb/rgbw/rgbww/xy/brightness/white)
- `fan_supports_speed` - fan has `SET_SPEED` feature
- `cover_supports_position` - cover has `SET_POSITION` feature
- `media_player_supports_pause` - media player has `PAUSE` feature
- `media_player_supports_volume_set` - media player has `VOLUME_SET` feature
- `media_player_supports_next_track` - media player has `NEXT_TRACK` feature
