### PR TITLE
Allow plural usage when asking about cover and lock states

### DIFF
--- a/speech_to_phrase/sentences/en.yaml
+++ b/speech_to_phrase/sentences/en.yaml
@@ -71,14 +71,14 @@ data:
   - sentences:
       - "(open|close) [the] {name}"
       - "(open|close) [the] {name} in [the] {area}"
-      - "is [the] {name} (open|closed)"
+      - "(is|are) [the] {name} (open|closed)"
     domains:
       - "cover"
 
   # locks
   - sentences:
       - "(lock|unlock) [the] {name}"
-      - "is [the] {name} (locked|unlocked)"
+      - "(is|are) [the] {name} (locked|unlocked)"
     domains:
       - "lock"
 


### PR DESCRIPTION
This PR allows using the plural form "are" when asking about the state of covers and locks.

In my case, I have a cover group entity called "Shades", so I want to be able to ask "are the shades open" instead of "is the shades open".

This is already supported by the intents engine: https://github.com/OHF-Voice/intents/blob/main/sentences/en/_common.yaml#L393