### PR TITLE
[DE] Add / Update German phrases for light, switch, sensor and climat…

### DIFF
--- a/speech_to_phrase/sentences/de.yaml
+++ b/speech_to_phrase/sentences/de.yaml
@@ -114,14 +114,17 @@ data:
       - "scene"
 
   # timers
-  - "<timer_set> [einen] Timer (auf|für) {seconds} Sekunden"
-  - "<timer_set> [einen] Timer (auf|für) 1 Minute"
-  - "<timer_set> [einen] Timer (auf|für) {minutes} Minuten"
-  - "<timer_set> [einen] Timer (auf|für) 1 Stunde"
-  - "<timer_set> [einen] Timer (auf|für) {hours} Stunden"
-  - "<timer_set> [einen] Timer (auf|für) 1 Stunde und 1 Minute"
-  - "<timer_set> [einen] Timer (auf|für) 1 Stunde und {minutes} Minuten"
-  - "<timer_set> [einen] Timer (auf|für) {hours} Stunden und {minutes} Minuten"
+  - "<timer_set> [einen|ein] {seconds} Sekunden Timer"
+  - "<timer_set> [einen|ein] {minutes} Minuten Timer"
+  - "<timer_set> [einen|ein] {hours} Stunden Timer"
+  - "<timer_set> [einen|ein] Timer (auf|für) {seconds} Sekunden"
+  - "<timer_set> [einen|ein] Timer (auf|für) 1 Minute"
+  - "<timer_set> [einen|ein] Timer (auf|für) {minutes} Minuten"
+  - "<timer_set> [einen|ein] Timer (auf|für) 1 Stunde"
+  - "<timer_set> [einen|ein] Timer (auf|für) {hours} Stunden"
+  - "<timer_set> [einen|ein] Timer (auf|für) 1 Stunde und 1 Minute"
+  - "<timer_set> [einen|ein] Timer (auf|für) 1 Stunde und {minutes} Minuten"
+  - "<timer_set> [einen|ein] Timer (auf|für) {hours} Stunden und {minutes} Minuten"
 
   - "<timer_cancel>[ (den|meinen)] Timer"
   - "<timer_cancel> (alle[ meine]|sämtliche) Timer"
@@ -131,34 +134,31 @@ data:
   - "Status (des|meines) Timers"
   - "wie lange läuft (der|mein) Timer noch"
 
-  # media
-  - "(pause|Weiter)"
-  - "nächster (Titel|Song)"
-  # - sentences:
-  #     - "(pause|resume) [the] {name}"
-  #     - "next [(track|item)] on [the] {name}"
-  #     - "skip [[the ](track|song)] on [the] {name}"
-  #   domains:
-  #     - "media_player"
+  # Medien
+  - "(pause|fortsetzen)"
+  - "nächster [(Titel|Eintrag)]"
+  - "überspringe [[diesen ](Titel|Song)]"
+  - sentences:
+      - "(pause|fortsetzen) [den] {name}"
+      - "nächster [(Titel|Eintrag)] auf [dem] {name}"
+      - "überspringe [[den ](Titel|Song)] auf [dem] {name}"
+    domains:
+      - "media_player"
 
-  # # temperature
+  # temperature
   - "wie[ (hoch|niedrig)] ist die temperatur"
-  - "wie[ (hoch|niedrig)] ist die temperatur in [der|dem] {area}"
+  - "wie[ (hoch|niedrig)] ist die temperatur (in|im) [der|dem] {area}"
   - "wie[ (hoch|niedrig)] ist die {area} temperatur"
-  - "wie warm ist es"
-  - "wie warm ist es im {area}"
-  - "wie warm ist es in [(der|dem)] {area}"
-   - sentences:
+  - sentences:
+      - "wie (warm|kalt) ist es"
+      - "wie warm ist [(der|die|das)] {name}"  
+    domains:
+      - "climate"
+
+  # sensors
+  - sentences:
       - "wie[ (hoch|niedrig)] ist die {name} temperatur"
       - "wie[ (hoch|niedrig)] ist die temperatur von [der|dem] {name}"
-      - "wie warm ist [(der|die|das)] {name}"
-     domains:
-       - "climate"
-
-  # # sensors
-  - sentences:
-      - "(wie|was) ist [der [wert von [dem|der]]] {name}"
-      - "wie hoch ist [der [wert von [dem|der]]] {name}"
     domains:
       - "sensor"
 


### PR DESCRIPTION
This is my first proposed change here. I’ve translated temperature, sensor, lights, and on/off intents into German hassil syntax. I hope I did everything correctly and followed the proper conventions .I’m not entirely sure how the testing works, but I tried to verify as much as possible through the developer tools -> assist sentence parsing debug tool in Home Assistant.
This should nearly complete the German translation. 

This should nearly complete the German translation. If this is all correct, I will probably do the rest in the future if  I have some time :)

**The changes:**

- Translated temperature intents (general, area, named) from English to natural German, including optional variations like "wie hoch/niedrig".

- Added on/off commands for devices and lights, including "ein" as an additional "on" option.

- Translated light intents for brightness and color, both for named lights and area-based lights.

- Translated sensor intents to German, preserving optional phrasing for "wert von" and allowing "wie hoch" as a natural variation.