### PR TITLE
Create hu.yaml - Hungarian Language Support

### DIFF
--- a/speech_to_phrase/const.py
+++ b/speech_to_phrase/const.py
@@ -52,6 +52,7 @@ class Language(str, Enum):
     SWAHILI = "sw"
     # THAI = "th"  bad model
     TURKISH = "tr"
+    HUNGARIAN = "hu"
 
 
 class Settings:

--- a/speech_to_phrase/models.py
+++ b/speech_to_phrase/models.py
@@ -342,6 +342,19 @@ MODELS: Dict[str, Model] = {
         sentences_language="tr",
         number_language="tr",
     ),
+    Language.HUNGARIAN.value: Model(
+        id="hu_HU-coqui",
+        type=ModelType.COQUI_STT,
+        language="hu_HU",
+        language_family="hu",
+        description="Hungarian Coqui STT model",
+        version="0.1.1",
+        author="Francis Tyers",
+        url="https://github.com/coqui-ai/STT-models",
+        casing=WordCasing.LOWER,
+        sentences_language="hu",
+        number_language="hu",
+    ),
 }
 
 DEFAULT_MODEL = MODELS[Language.ENGLISH]

--- a/speech_to_phrase/sentences/hu.yaml
+++ b/speech_to_phrase/sentences/hu.yaml
@@ -1,0 +1,160 @@
+---
+language: "hu"
+
+lists:
+  color:
+    - "fehér"
+    - "fekete"
+    - "piros"
+    - "narancssárga"
+    - "citromsárga"
+    - "zöld"
+    - "kék"
+    - "lila"
+    - "barna"
+    - "rózsaszín"
+    - "türkiz"
+
+wildcards:
+  - "todo_item"
+
+data:
+  # cancel
+  - "megszakítás"
+
+  # date and time
+  - "mennyi az idő"
+  - "mennyi a pontos idő"
+  - "hány óra van"
+  - "hányadika van [ma]"
+  - "mi a pontos dátum [ma]"
+
+  # weather
+  - "(milyen|hogy néz ki) az időjárás"
+  - "(milyen|hogy alakul) az időjárás"
+  - sentences:
+      - "(milyen|hogy alakul) {name} időjárása"
+    domains:
+      - "weather"
+
+  # generic on/off
+  - sentences:
+      - "kapcsold (be|ki) [a(z)] {name}-t"
+      - "kapcsold (be|ki) [a(z)] {name}-t a(z) {area}-ban"
+      - "kapcsold (be|ki) [a(z)] {area} {name}-t"
+    domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+
+
+  # lights (name)
+  # - sentences:
+  #     - "set [the] brightness of [the] {name} to {brightness} percent"
+  #     - "set [the] {name} brightness to {brightness} percent"
+  #   domains:
+  #     - "light"
+  #   light_supports_brightness: true
+
+  # - sentences:
+  #     - "set [the] [color of [the]] {name} to {color}"
+  #     - "set [the] {name} [color] to {color}"
+  #   domains:
+  #     - "light"
+  #   light_supports_color: true
+
+  # doors and windows
+  - "((nyisd ki|csukd be)) [a(z)] (redőnyt|függönyt|ablakot) [a(z)] {area}-ban"
+  - "((nyisd ki|csukd be)) [a(z)] {area} (redőnyt|függönyt|ablakot)"
+
+  - sentences:
+      - "((nyisd ki|csukd be)) [a(z)] {name}-t"
+      - "((nyisd ki|csukd be)) [a(z)] {name}-t [a(z)] {area}-ban"
+      - "(nyitva van-e|csukva van-e) [a(z)] {name}"
+    domains:
+      - "cover"
+
+
+  # locks
+  - sentences:
+      - "(zárd be|nyisd ki) [a(z)] {name}-t"
+      - "(be van-e zárva|ki van-e nyitva) [a(z)] {name}"
+    domains:
+      - "lock"
+
+  # scripts and scenes
+  - sentences:
+      - "futtasd [a(z)] {name} [szkriptet]"
+    domains:
+      - "script"
+
+  - sentences:
+      - "aktiváld [a(z)] {name} [jelenetet]"
+    domains:
+      - "scene"
+
+  # timers
+  - "(állíts|indíts|hozz létre) egy időzítőt {seconds} másodpercre"
+  - "(állíts|indíts|hozz létre) egy időzítőt 1 percre"
+  - "(állíts|indíts|hozz létre) egy időzítőt {minutes} percre"
+  - "(állíts|indíts|hozz létre) egy időzítőt 1 percre és {seconds} másodpercre"
+  - "(állíts|indíts|hozz létre) egy időzítőt {minutes} percre és {seconds} másodpercre"
+  - "(állíts|indíts|hozz létre) egy időzítőt {minutes} és fél percre"
+  - "(állíts|indíts|hozz létre) egy időzítőt 1 órára"
+  - "(állíts|indíts|hozz létre) egy időzítőt {hours} órára"
+  - "(állíts|indíts|hozz létre) egy időzítőt {hours} és fél órára"
+  - "(állíts|indíts|hozz létre) egy időzítőt 1 órára és 1 percre"
+  - "(állíts|indíts|hozz létre) egy időzítőt 1 órára és {minutes} percre"
+  - "(állíts|indíts|hozz létre) egy időzítőt {hours} órára és {minutes} percre"
+
+  - "(állítsd le|állítsd meg|töröld) [az|a] időzítőt"
+  - "(állítsd le|állítsd meg|töröld) az összes időzítőt"
+  - "(szüneteltesd|folytasd) [az|a] időzítőt"
+
+  - "időzítő állapota"
+  - "mi az időzítő állapota"
+  - "mennyit mutat az időzítő"
+  - "mennyi idő van még hátra [az|a] időzítőn"
+  - "mennyi idő van még hátra az időzítőkből"
+
+
+  # media
+  - "(szünet|folytatás)"
+  - "következő [szám|track]"
+  - "ugorj [[erre a ](számra|dalra)]"
+
+  - sentences:
+      - "(szüneteltesd|folytasd) [a(z)] {name}-t"
+      - "következő [szám|track] a(z) {name}-en"
+      - "ugord át [a(z)] (számot|dalt) a(z) {name}-en"
+    domains:
+      - "media_player"
+
+
+  # temperature
+  - "mennyi a hőmérséklet"
+  - "mennyi a hőmérséklet [a(z)] {area}-ban"
+  - "mennyi [a(z)] {area} hőmérséklete"
+
+  - sentences:
+      - "mennyi [a(z)] {name} hőmérséklete"
+      - "mennyi a hőmérséklet [a(z)] {name}-nél"
+    domains:
+      - "climate"
+
+
+  # sensors
+  - sentences:
+      - "mennyi [a(z) [értéke [a(z)]]] {name}-nek"
+    domains:
+      - "sensor"
+
+
+  # todo
+  - sentences:
+      - "add hozzá {todo_item}-t [a(z)|a] {name}-hez"
+    domains:
+      - "todo"
+


### PR DESCRIPTION
The following changes have been made:

* `hu.yaml` created
* `const.py` updated with HUNGARIAN constant
* `models.py` updated with Hungarian Coqui STT model

Unfortunately, this is as far as I’ve gotten on my own, but if I receive some guidance, I would be happy to help with the integration of the Hungarian language.