### PR TITLE
feat(de): enhance german speech recognition phrases

### DIFF
--- a/NEW_SENTENCES_BASE.md
+++ b/NEW_SENTENCES_BASE.md
@@ -1,0 +1,29 @@
+Timers
+	Start with duration
+		Pause
+		Resume
+		Cancel
+		Status
+
+Media
+	Pause (or “stop”) 
+	Resume
+	Next
+	Volume up
+	Volume down
+	Volume set percentage
+
+Lights in current area
+	On
+	Off
+	Brightness up
+	Brightness down
+	Brightness set percentage
+
+Time
+Date
+
+Weather (no name)
+
+Cancel:
+    nevermind/stop

--- a/speech_to_phrase/sentences/de.yaml
+++ b/speech_to_phrase/sentences/de.yaml
@@ -23,25 +23,28 @@ wildcards:
 data:
   # cancel
   - "vergiss es"
+  - "stop"
 
   # date and time
   - "wie spät ist es"
   - "wie viel uhr (ist es|haben wir)[ jetzt]"
   - "(welchen tag|welches datum) haben wir heute"
   - "(welcher tag|welches datum) ist heute"
+  - "Was ist heute für ein Tag"
 
   # weather
   - "wie ist das Wetter"
   - sentences:
       - "wie ist das Wetter (für|in) {name}"
-      - "was für[ ein] Wetter (ist|hat es) in {name}"
     domains:
       - "weather"
 
   # # lights (area)
-  - "[alle|die] lichter (an|ein|aus)(schalten|machen) "
-  - "(schalt|mach)[e] [alle|die] lichter (an|ein|aus)"
-  - "(schalt|mach)[e] [alle|die] lichter in [der|dem] {area} (an|ein|aus)"
+  - "[alle|die] (lichter|lampen) (an|ein|aus)(schalten|machen)"
+  - "(schalt|mach)[e] [alle|die] (lichter|lampen) (an|ein|aus)"
+  - "(schalt|mach)[e] [alle|die] (lichter|lampen) in [der|dem] {area} (an|ein|aus)"
+  - "schalt[e] {name} (an|ein|aus)"
+  - "[schalte ][ das]licht[er] [(an|ein|aus|einschalten|schalten|machen|ausschalten)]"
 
   - "stell[e] [die] helligkeit [hier] auf {brightness} prozent"
   - "stell[e] [die] helligkeit von [der|dem] {area} auf {brightness} prozent"
@@ -102,14 +105,16 @@ data:
       - "media_player"
       - "input_boolean"
 
-  # scripts and scenes
+  # scripts
   - sentences:
       - "aktiviere {name} Skript"
+      - "starte[ das] {name} [Skript]"
     domains:
       - "script"
-
+  
+  # scenes
   - sentences:
-      - "aktiviere {name} Szene"
+      - "aktiviere[ die] {name} Szene"
     domains:
       - "scene"
 
@@ -125,7 +130,9 @@ data:
   - "<timer_set> [einen|ein] Timer (auf|für) 1 Stunde und 1 Minute"
   - "<timer_set> [einen|ein] Timer (auf|für) 1 Stunde und {minutes} Minuten"
   - "<timer_set> [einen|ein] Timer (auf|für) {hours} Stunden und {minutes} Minuten"
-
+  - "{seconds} Sekunden Timer[ bitte]"
+  - "{minutes} Minuten Timer[ bitte]"
+  - "{hours} Stunden Timer[ bitte]"
   - "<timer_cancel>[ (den|meinen)] Timer"
   - "<timer_cancel> (alle[ meine]|sämtliche) Timer"
   - "pausiere[ (den|meinen)] Timer"
@@ -150,7 +157,7 @@ data:
   - "wie[ (hoch|niedrig)] ist die temperatur (in|im) [der|dem] {area}"
   - "wie[ (hoch|niedrig)] ist die {area} temperatur"
   - sentences:
-      - "wie (warm|kalt) ist es"
+      - "wie (warm|kalt) ist es[ hier]"
       - "wie warm ist [(der|die|das)] {name}"  
     domains:
       - "climate"


### PR DESCRIPTION
Add new German phrases for various commands (stop, date/time, lights, scripts, timer, temperature) and include a documentation file for managing base sentences.