### PR TITLE
I believe this is everything that was still missing for Slovene part

### DIFF
--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -1,19 +1,19 @@
 ---
 language: "sl"
 
-# lists:
-#   color:
-#     - "bela"
-#     - "black"
-#     - "red"
-#     - "orange"
-#     - "yellow"
-#     - "green"
-#     - "blue"
-#     - "purple"
-#     - "brown"
-#     - "pink"
-#     - "turquoise"
+lists:
+  color:
+    - "bela|belo"
+    - "črna|črno"
+    - "rdeča|rdečo"
+    - "oranžna|oranžno"
+    - "rumena|rumeno"
+    - "zelena|zeleno"
+    - "modra|modro"
+    - "vijolična|vijolično"
+    - "rjava|rjavo"
+    - "pink"
+    - "turkizna|turkizno"
 
 data:
   # cancel
@@ -24,42 +24,42 @@ data:
   - "koliko je ura"
   - "kateri dan je danes"
 
-  # # weather
-  # - "(what's|what is) the weather [like]"
-  # - sentences:
-  #     - "(what's|what is) the {name} weather [like]"
-  #     - "(what's|what is) the weather [like] in {name}"
-  #   domains:
-  #     - "weather"
+  # weather
+  - "[kakšno je] vreme"
+  - sentences:
+      - "[kakšno je] vreme v mestu {name} "
+      - "(kakšno je) vreme v {name}"
+    domains:
+      - "weather"
 
-  # # lights (area)
-  # - "turn (on|off) [the] lights [in here]"
-  # - "turn [the] lights (on|off) [in here]"
-  # - "turn (on|off) [all|the|all of the] {area} lights"
-  # - "turn (on|off) [all|the|all of the] lights in [the] {area}"
-  # - "set [the] brightness [in here] to {brightness} percent"
-  # - "set [the] brightness of [the] {area} to {brightness} percent"
-  # - "set [the] {area} brightness to {brightness} percent"
-  # - "set [the] lights [in here] to {color}"
-  # - "set [[the] color of the] lights [in here] to {color}"
-  # - "set [the] [color of [the]] {area} lights to {color}"
-  # - "set [the] {area} lights to {color}"
-  # - "set lights in [the] {area} to {color}"
+  # lights (area)
+  - "(prižgi|ugasni) luč [tu|tukaj]"
+  - "(prižgi|ugasni) [tu|tukaj]"
+  - "prižgi|ugasni [vse| {area} luči"
+  - "prižgi|ugasni [vse| luči [v] {area}"
+  - "nastavi (svetlost|jakost svetlobe] [tu|tukaj] na {brightness} odstotkov"
+  - "nastavi svetlost {area} na {brightness} odstotkov"
+  - "nastavi {area} na {brightness} odstotkov [svetlobe]"
+  - "nastavi luč [in here] na {color}"
+  - "nastavi [barvo] (luč|luči) [tu|tukaj|v tem prostoru] na {color}"
+  - "nastavi [barvo] (luč|luči) v {area} na {color} [barvo]"
+  - "nastavi {area} (luč|luči) na {color}"
+  - "nastavi luči v {area} na {color} [barvo]"
 
-  # # lights (name)
-  # - sentences:
-  #     - "set [the] brightness of [the] {name} to {brightness} percent"
-  #     - "set [the] {name} brightness to {brightness} percent"
-  #   domains:
-  #     - "light"
-  #   light_supports_brightness: true
+  # lights (name)
+  - sentences:
+      - "nastavi (svetlost|jakost svetlobe] {name} na {brightness} odstotkov"
+      - "nastavi {name} na  (svetlost|jakost svetlobe] {brightness} odstotkov"
+    domains:
+      - "light"
+    light_supports_brightness: true
 
-  # - sentences:
-  #     - "set [the] [color of [the]] {name} to {color}"
-  #     - "set [the] {name} [color] to {color}"
-  #   domains:
-  #     - "light"
-  #   light_supports_color: true
+  - sentences:
+      - "nastavi [barvo] {name} na {color}"
+      - "nastavi {name} na {color} [barvo]"
+    domains:
+      - "light"
+    light_supports_color: true
 
   # # doors and windows
   # - "(open|close) [the] (blinds|curtains|windows) in [the] {area}"

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -102,19 +102,19 @@ data:
     domains:
       - "scene"
 
-  # # timers
-  # - "(set|start|create) [a] timer for {seconds} seconds"
-  # - "(set|start|create) [a] timer for 1 minute"
-  # - "(set|start|create) [a] timer for {minutes} minutes"
-  # - "(set|start|create) [a] timer for 1 minute and {seconds} seconds"
-  # - "(set|start|create) [a] timer for {minutes} minutes and {seconds} seconds"
-  # - "(set|start|create) [a] timer for {minutes} and a half minutes"
-  # - "(set|start|create) [a] timer for 1 hour"
-  # - "(set|start|create) [a] timer for {hours} hours"
-  # - "(set|start|create) [a] timer for {hours} and a half hours"
-  # - "(set|start|create) [a] timer for 1 hour and 1 minute"
-  # - "(set|start|create) [a] timer for 1 hour and {minutes} minutes"
-  # - "(set|start|create) [a] timer for {hours} hours and {minutes} minutes"
+  # timers
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 minuto"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 minuto in {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} (minut|minuto) in {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} in pol minute"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} ur"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} in pol ure"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in 1 minuto"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} (ur|uro) in {minutes} minut"
 
   # - "(cancel|stop) [the|my] timer"
   # - "(cancel|stop) all [[of ](the|my)] timers"

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -29,35 +29,21 @@ data:
   - "kateri dan je danes"
 
   # weather
-  - "[kakšno je] vreme"
   - sentences:
-      - "[kakšno je] vreme v mestu {name} "
       - "(kakšno je) vreme v {name}"
     domains:
       - "weather"
 
   # lights (area)
-  - "(prižgi|ugasni) luč [tu|tukaj]"
-  - "(prižgi|ugasni) [tu|tukaj]"
+  - "(prižgi|ugasni) (luč|luči) [tu|tukaj]"
   - "(prižgi|ugasni) [vse] {area} luči"
   - "(prižgi|ugasni) [vse] luči [v] {area}"
   - "nastavi (svetlost|jakost svetlobe) [tu|tukaj] na {brightness} odstotkov"
   - "nastavi svetlost {area} na {brightness} odstotkov"
   - "nastavi {area} na {brightness} odstotkov [svetlobe]"
-  - "nastavi luč [tu|tukaj] na {color}"
-  - "nastavi [barvo] (luč|luči) [tu|tukaj|v tem prostoru] na {color}"
   - "nastavi [barvo] (luč|luči) v {area} na {color} [barvo]"
-  - "nastavi {area} (luč|luči) na {color}"
-  - "nastavi luči v {area} na {color} [barvo]"
 
   # lights (name)
-  - sentences:
-      - "nastavi (svetlost|jakost svetlobe) {name} na {brightness} odstotkov"
-      - "nastavi {name} na (svetlost|jakost svetlobe) {brightness} odstotkov"
-    domains:
-      - "light"
-    light_supports_brightness: true
-
   - sentences:
       - "nastavi [barvo] {name} na {color}"
       - "nastavi {name} na {color} [barvo]"
@@ -77,8 +63,8 @@ data:
 
   # locks
   - sentences:
-      - "(zakleni|odkleni)  {name}"
-      - "je  {name} ((zaklenjen|zaklenjena)|(odklenjen|odklenjena))"
+      - "(zakleni|odkleni) {name}"
+      - "je {name} ((zaklenjen|zaklenjena)|(odklenjen|odklenjena))"
     domains:
       - "lock"
 
@@ -86,7 +72,6 @@ data:
   - sentences:
       - "(vklopi|izklopi) {name}"
       - "(vklopi|izklopi) {name} [v] {area}"
-      # - "turn [the] {name} in [the] {area} (on|off)"
     domains:
       - "light"
       - "switch"
@@ -96,7 +81,7 @@ data:
 
   # scripts and scenes
   - sentences:
-      - "zaženi [skripto|skript] {name} "
+      - "zaženi [skripto|skript] {name}"
     domains:
       - "script"
 
@@ -111,7 +96,6 @@ data:
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {minutes} minut"
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 minuto in {seconds} sekund"
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {minutes} (minut|minuto) in {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {minutes} in pol minute"
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 uro"
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {hours} ur"
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {hours} in pol ure"
@@ -127,12 +111,9 @@ data:
   - "[koliko] časa [je] ostalo na časovniku"
 
   # media
-  - "((pavziraj|pavza)|nadaljuj)"
-  - "naslednja [pesem]"
-  - "preskoči [[to] pesem]"
   - sentences:
-      - "((pavziraj|pavza)|nadaljuj) {name}"
-      - "naslednja [pesem] na {name}"
+      - "((pavziraj|pavza|zaustavi)|nadaljuj) {name}"
+      - "naslednj(o|i|e) [pesem] na {name}"
       - "preskoči [pesem] na {name}"
     domains:
       - "media_player"
@@ -142,7 +123,7 @@ data:
   - "(kakšna je|koliko je) (temp|temperatura) v {area}"
   - "(temp|temperatura) [v] {area}"
   - sentences:
-      - "(kakšna je|koliko je) (temp|temperatura) [v] {name}"
+      - "(temp|temperatura) {name}"
     domains:
       - "climate"
 

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -3,7 +3,7 @@ language: "sl"
 
 # lists:
 #   color:
-#     - "white"
+#     - "bela"
 #     - "black"
 #     - "red"
 #     - "orange"

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -1,6 +1,9 @@
 ---
 language: "sl"
 
+wildcards:
+  - "todo_item"
+
 lists:
   color:
     - "bela|belo"
@@ -36,12 +39,12 @@ data:
   # lights (area)
   - "(prižgi|ugasni) luč [tu|tukaj]"
   - "(prižgi|ugasni) [tu|tukaj]"
-  - "prižgi|ugasni [vse| {area} luči"
-  - "prižgi|ugasni [vse| luči [v] {area}"
-  - "nastavi (svetlost|jakost svetlobe] [tu|tukaj] na {brightness} odstotkov"
+  - "(prižgi|ugasni) [vse] {area} luči"
+  - "(prižgi|ugasni) [vse] luči [v] {area}"
+  - "nastavi (svetlost|jakost svetlobe) [tu|tukaj] na {brightness} odstotkov"
   - "nastavi svetlost {area} na {brightness} odstotkov"
   - "nastavi {area} na {brightness} odstotkov [svetlobe]"
-  - "nastavi luč [in here] na {color}"
+  - "nastavi luč [tu|tukaj] na {color}"
   - "nastavi [barvo] (luč|luči) [tu|tukaj|v tem prostoru] na {color}"
   - "nastavi [barvo] (luč|luči) v {area} na {color} [barvo]"
   - "nastavi {area} (luč|luči) na {color}"
@@ -49,8 +52,8 @@ data:
 
   # lights (name)
   - sentences:
-      - "nastavi (svetlost|jakost svetlobe] {name} na {brightness} odstotkov"
-      - "nastavi {name} na  (svetlost|jakost svetlobe] {brightness} odstotkov"
+      - "nastavi (svetlost|jakost svetlobe) {name} na {brightness} odstotkov"
+      - "nastavi {name} na (svetlost|jakost svetlobe) {brightness} odstotkov"
     domains:
       - "light"
     light_supports_brightness: true
@@ -66,13 +69,13 @@ data:
   - "(odpri|zapri) (rolete|zavese|okna) [v] {area}"
   - "(odpri|zapri) {area} (rolete|zavese|okna)"
   - sentences:
-      - "(open|close) [the] {name}"
-      - "(open|close) [the] {name} in [the] {area}"
-      - "is [the] {name} (open|closed)"
+      - "(odpri|zapri) {name}"
+      - "(odpri|zapri) {name} [v] {area}"
+      - "je {name} (odprt|odprta|zaprt|zaprta)"
     domains:
       - "cover"
 
-  locks
+  # locks
   - sentences:
       - "(zakleni|odkleni)  {name}"
       - "je  {name} ((zaklenjen|zaklenjena)|(odklenjen|odklenjena))"
@@ -98,7 +101,7 @@ data:
       - "script"
 
   - sentences:
-      - "activate [the] {name} [scene]"
+      - "aktiviraj {name} [sceno]"
     domains:
       - "scene"
 
@@ -148,3 +151,9 @@ data:
       - "koliko je [vrednost] {name}"
     domains:
       - "sensor"
+
+  # todo
+  - sentences:
+      - "dodaj {todo_item} [na] {name} [seznam]"
+    domains:
+      - "todo"

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -15,6 +15,9 @@ lists:
     - "pink"
     - "turkizna|turkizno"
 
+wildcards:
+  - "todo_item"
+
 data:
   # cancel
   - "prekini"
@@ -26,31 +29,23 @@ data:
   - "kateri dan je danes"
 
   # weather
-  - "[kakšno je] vreme"
   - sentences:
-      - "[kakšno je] vreme v mestu {name} "
       - "(kakšno je) vreme v {name}"
     domains:
       - "weather"
 
   # lights (area)
   - "(prižgi|ugasni) luč [tu|tukaj]"
-  - "(prižgi|ugasni) [tu|tukaj]"
-  - "prižgi|ugasni [vse| {area} luči"
-  - "prižgi|ugasni [vse| luči [v] {area}"
-  - "nastavi (svetlost|jakost svetlobe] [tu|tukaj] na {brightness} odstotkov"
+  - "(prižgi|ugasni) [vse] {area} luči"
+  - "(prižgi|ugasni) [vse] luči [v] {area}"
+  - "nastavi (svetlost|jakost svetlobe) [tu|tukaj] na {brightness} odstotkov"
   - "nastavi svetlost {area} na {brightness} odstotkov"
   - "nastavi {area} na {brightness} odstotkov [svetlobe]"
-  - "nastavi luč [in here] na {color}"
-  - "nastavi [barvo] (luč|luči) [tu|tukaj|v tem prostoru] na {color}"
   - "nastavi [barvo] (luč|luči) v {area} na {color} [barvo]"
-  - "nastavi {area} (luč|luči) na {color}"
-  - "nastavi luči v {area} na {color} [barvo]"
 
   # lights (name)
   - sentences:
-      - "nastavi (svetlost|jakost svetlobe] {name} na {brightness} odstotkov"
-      - "nastavi {name} na  (svetlost|jakost svetlobe] {brightness} odstotkov"
+      - "nastavi {name} na {brightness} odstotkov [svetlosti]"
     domains:
       - "light"
     light_supports_brightness: true
@@ -66,16 +61,16 @@ data:
   - "(odpri|zapri) (rolete|zavese|okna) [v] {area}"
   - "(odpri|zapri) {area} (rolete|zavese|okna)"
   - sentences:
-      - "(open|close) [the] {name}"
-      - "(open|close) [the] {name} in [the] {area}"
-      - "is [the] {name} (open|closed)"
+      - "(odpri|zapri) {name}"
+      - "(odpri|zapri) {name} v {area}"
+      - "je {name} (odprt|odprta|zaprt|zaprta)"
     domains:
       - "cover"
 
-  locks
+  # locks
   - sentences:
-      - "(zakleni|odkleni)  {name}"
-      - "je  {name} ((zaklenjen|zaklenjena)|(odklenjen|odklenjena))"
+      - "(zakleni|odkleni) {name}"
+      - "je {name} ((zaklenjen|zaklenjena)|(odklenjen|odklenjena))"
     domains:
       - "lock"
 
@@ -93,28 +88,28 @@ data:
 
   # scripts and scenes
   - sentences:
-      - "zaženi [skripto|skript] {name} "
+      - "zaženi [skripto|skript] {name}"
     domains:
       - "script"
 
   - sentences:
-      - "activate [the] {name} [scene]"
+      - "aktiviraj [sceno] {name}"
     domains:
       - "scene"
 
   # timers
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 minuto"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} minut"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 minuto in {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} (minut|minuto) in {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} in pol minute"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} ur"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} in pol ure"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in 1 minuto"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in {minutes} minut"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} (ur|uro) in {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za 1 minuto"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za 1 minuto in {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {minutes} (minut|minuto) in {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {minutes} minut in pol"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za 1 uro"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {hours} (ur|uri|uro)"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {hours} in pol ure"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za 1 uro in 1 minuto"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za 1 uro in {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] za {hours} (ur|uri|uro) in {minutes} minut"
 
   - "(prekini|ustavi) [časovnik|štoperico|timer]"
   - "(prekini|ustavi) vse časovnike"
@@ -124,12 +119,9 @@ data:
   - "[koliko] časa [je] ostalo na časovniku"
 
   # media
-  - "((pavziraj|pavza)|nadaljuj)"
-  - "naslednja [pesem]"
-  - "preskoči [[to] pesem]"
   - sentences:
-      - "((pavziraj|pavza)|nadaljuj) {name}"
-      - "naslednja [pesem] na {name}"
+      - "(zaustavi|nadaljuj) {name}"
+      - "naslednje [pesem] na {name}"
       - "preskoči [pesem] na {name}"
     domains:
       - "media_player"
@@ -137,9 +129,9 @@ data:
   # temperature
   - "(kakšna je|koliko je) (temp|temperatura)"
   - "(kakšna je|koliko je) (temp|temperatura) v {area}"
-  - "(temp|temperatura) |v| {area} "
+  - "(temp|temperatura) {area}"
   - sentences:
-      - "(kakšna je|koliko je) (temp|temperatura) [v] {name}"
+      - "(temp|temperatura) {name}"
     domains:
       - "climate"
 
@@ -148,3 +140,9 @@ data:
       - "koliko je [vrednost] {name}"
     domains:
       - "sensor"
+
+  # todo
+  - sentences:
+      - "dodaj {todo_item} na [moj] {name}"
+    domains:
+      - "todo"

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -106,18 +106,18 @@ data:
       - "scene"
 
   # timers
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 minuto"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} minut"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 minuto in {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} (minut|minuto) in {seconds} sekund"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {minutes} in pol minute"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} ur"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} in pol ure"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in 1 minuto"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in {minutes} minut"
-  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} (ur|uro) in {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 minuto"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 minuto in {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {minutes} (minut|minuto) in {seconds} sekund"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {minutes} in pol minute"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 uro"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {hours} ur"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {hours} in pol ure"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 uro in 1 minuto"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) 1 uro in {minutes} minut"
+  - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] (na|za) {hours} (ur|uro) in {minutes} minut"
 
   - "(prekini|ustavi) [časovnik|štoperico|timer]"
   - "(prekini|ustavi) vse časovnike"
@@ -140,7 +140,7 @@ data:
   # temperature
   - "(kakšna je|koliko je) (temp|temperatura)"
   - "(kakšna je|koliko je) (temp|temperatura) v {area}"
-  - "(temp|temperatura) |v| {area} "
+  - "(temp|temperatura) [v] {area}"
   - sentences:
       - "(kakšna je|koliko je) (temp|temperatura) [v] {name}"
     domains:

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -72,12 +72,12 @@ data:
     domains:
       - "cover"
 
-  # locks
-  # - sentences:
-  #     - "(lock|unlock) [the] {name}"
-  #     - "is [the] {name} (locked|unlocked)"
-  #   domains:
-  #     - "lock"
+  locks
+  - sentences:
+      - "(zakleni|odkleni)  {name}"
+      - "je  {name} ((zaklenjen|zaklenjena)|(odklenjen|odklenjena))"
+    domains:
+      - "lock"
 
   # generic on/off
   - sentences:
@@ -116,36 +116,35 @@ data:
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na 1 uro in {minutes} minut"
   - "(nastavi|zaženi|ustvari) [časovnik|štoperico|timer] na {hours} (ur|uro) in {minutes} minut"
 
-  # - "(cancel|stop) [the|my] timer"
-  # - "(cancel|stop) all [[of ](the|my)] timers"
-  # - "(pause|resume) [the|my] timer"
-  # - "timer status"
-  # - "status of [the|my] timer[s]"
-  # - "[how much] time [is] left on [the|my] timer[s]"
+  - "(prekini|ustavi) [časovnik|štoperico|timer]"
+  - "(prekini|ustavi) vse časovnike"
+  - "(pavziraj|nadaljuj) [časovnik|štoperico|timer]"
+  - "status časovnika"
+  - "status [vseh] časovnikov"
+  - "[koliko] časa [je] ostalo na časovniku"
 
-  # # media
-  # - "(pause|resume)"
-  # - "next [(track|item)]"
-  # - "skip [[this ](track|song)]"
-  # - sentences:
-  #     - "(pause|resume) [the] {name}"
-  #     - "next [(track|item)] on [the] {name}"
-  #     - "skip [[the ](track|song)] on [the] {name}"
-  #   domains:
-  #     - "media_player"
+  # media
+  - "((pavziraj|pavza)|nadaljuj)"
+  - "naslednja [pesem]"
+  - "preskoči [[to] pesem]"
+  - sentences:
+      - "((pavziraj|pavza)|nadaljuj) {name}"
+      - "naslednja [pesem] na {name}"
+      - "preskoči [pesem] na {name}"
+    domains:
+      - "media_player"
 
-  # # temperature
-  # - "(what is|what's) the (temp|temperature)"
-  # - "(what is|what's) the (temp|temperature) in [the] {area}"
-  # - "(what is|what's) the {area} (temp|temperature)"
-  # - sentences:
-  #     - "(what is|what's) the {name} (temp|temperature)"
-  #     - "(what is|what's) the (temp|temperature) of [the] {name}"
-  #   domains:
-  #     - "climate"
+  # temperature
+  - "(kakšna je|koliko je) (temp|temperatura)"
+  - "(kakšna je|koliko je) (temp|temperatura) v {area}"
+  - "(temp|temperatura) |v| {area} "
+  - sentences:
+      - "(kakšna je|koliko je) (temp|temperatura) [v] {name}"
+    domains:
+      - "climate"
 
-  # # sensors
-  # - sentences:
-  #     - "what is [the [value of [the]]] {name}"
-  #   domains:
-  #     - "sensor"
+  # sensors
+  - sentences:
+      - "koliko je [vrednost] {name}"
+    domains:
+      - "sensor"

--- a/speech_to_phrase/sentences/sl.yaml
+++ b/speech_to_phrase/sentences/sl.yaml
@@ -19,6 +19,7 @@ data:
   # cancel
   - "prekini"
   - "prekliči"
+  - "pozabi"
 
   # date and time
   - "koliko je ura"
@@ -61,17 +62,17 @@ data:
       - "light"
     light_supports_color: true
 
-  # # doors and windows
-  # - "(open|close) [the] (blinds|curtains|windows) in [the] {area}"
-  # - "(open|close) [the] {area} (blinds|curtains|windows)"
-  # - sentences:
-  #     - "(open|close) [the] {name}"
-  #     - "(open|close) [the] {name} in [the] {area}"
-  #     - "is [the] {name} (open|closed)"
-  #   domains:
-  #     - "cover"
+  # doors and windows
+  - "(odpri|zapri) (rolete|zavese|okna) [v] {area}"
+  - "(odpri|zapri) {area} (rolete|zavese|okna)"
+  - sentences:
+      - "(open|close) [the] {name}"
+      - "(open|close) [the] {name} in [the] {area}"
+      - "is [the] {name} (open|closed)"
+    domains:
+      - "cover"
 
-  # # locks
+  # locks
   # - sentences:
   #     - "(lock|unlock) [the] {name}"
   #     - "is [the] {name} (locked|unlocked)"
@@ -81,7 +82,7 @@ data:
   # generic on/off
   - sentences:
       - "(vklopi|izklopi) {name}"
-      # - "turn (on|off) [the] {name} in [the] {area}"
+      - "(vklopi|izklopi) {name} [v] {area}"
       # - "turn [the] {name} in [the] {area} (on|off)"
     domains:
       - "light"
@@ -90,16 +91,16 @@ data:
       - "media_player"
       - "input_boolean"
 
-  # # scripts and scenes
-  # - sentences:
-  #     - "run [the] {name} [script]"
-  #   domains:
-  #     - "script"
+  # scripts and scenes
+  - sentences:
+      - "zaženi [skripto|skript] {name} "
+    domains:
+      - "script"
 
-  # - sentences:
-  #     - "activate [the] {name} [scene]"
-  #   domains:
-  #     - "scene"
+  - sentences:
+      - "activate [the] {name} [scene]"
+    domains:
+      - "scene"
 
   # # timers
   # - "(set|start|create) [a] timer for {seconds} seconds"

--- a/tests/fixtures/sl.yaml
+++ b/tests/fixtures/sl.yaml
@@ -2,6 +2,9 @@
 language: "sl"
 
 fixtures:
+  areas:
+    - name: "Kuhinja"
+
   entities:
     - name:
         - "luč v spalnici"
@@ -9,3 +12,32 @@ fixtures:
         - "luči v spalnici"
         - "lučka v spalnici"
       domain: "light"
+      light_supports_brightness: true
+      light_supports_color: true
+
+    - name: "New York"
+      domain: "weather"
+
+    - name: "EcoBee"
+      domain: "climate"
+
+    - name: "Garažna vrata"
+      domain: "cover"
+
+    - name: "Vhodna vrata"
+      domain: "lock"
+
+    - name: "TV"
+      domain: "media_player"
+
+    - name: "Zabava"
+      domain: "script"
+
+    - name: "Romantično"
+      domain: "scene"
+
+    - name: "Zunanja vlažnost"
+      domain: "sensor"
+
+    - name: "Nakupovalni seznam"
+      domain: "todo"

--- a/tests/fixtures/sl.yaml
+++ b/tests/fixtures/sl.yaml
@@ -2,10 +2,58 @@
 language: "sl"
 
 fixtures:
+  areas:
+    - name:
+        - "spalnica"
+        - "spalnici"
+        - "spalnico"
+        - "spalnice"
+
   entities:
+    - name: "Maribor"
+      domain: "weather"
+
     - name:
         - "luč v spalnici"
         - "lučko v spalnici"
         - "luči v spalnici"
         - "lučka v spalnici"
       domain: "light"
+      light_supports_brightness: true
+      light_supports_color: true
+
+    - name: "garažna vrata"
+      domain: "cover"
+
+    - name:
+        - "vhodna vrata"
+        - "vhodnih vrat"
+      domain: "lock"
+
+    - name:
+        - "televizor"
+        - "televizorja"
+        - "televizorju"
+      domain: "media_player"
+      media_player_supports_pause: true
+      media_player_supports_next_track: true
+
+    - name: "domača zabava"
+      domain: "script"
+
+    - name: "nočna razsvetljava"
+      domain: "scene"
+
+    - name:
+        - "termostat"
+        - "termostata"
+        - "termostatu"
+      domain: "climate"
+
+    - name:
+        - "vlažnost zraka"
+        - "vlažnosti zraka"
+      domain: "sensor"
+
+    - name: "nakupovalni seznam"
+      domain: "todo"

--- a/tests/sentences/sl.yaml
+++ b/tests/sentences/sl.yaml
@@ -11,10 +11,7 @@ sentences:
   - "koliko je ura"
   - "kateri dan je danes"
 
-  # weather
-  - "vreme"
-  - "kakšno je vreme"
-  - "kakšno je vreme v mestu New York"
+  # weather (bare weather query fails HA; must include entity name)
   - "kakšno je vreme v New York"
 
   # lights (area)
@@ -33,9 +30,8 @@ sentences:
   - "nastavi luči v Kuhinja na rumeno barvo"
 
   # lights (name)
-  - "nastavi svetlost luč v spalnici na 75 odstotkov"
-  - "nastavi lučko v spalnici na svetlost 10 odstotkov"
-  - "nastavi barvo luč v spalnici na vijolično"
+  - "nastavi svetlost lučko v spalnici na 75 odstotkov svetlosti"
+  - "nastavi barvo lučko v spalnici na modro"
   - "nastavi lučko v spalnici na oranžno barvo"
 
   # doors and windows
@@ -64,19 +60,16 @@ sentences:
   - "zaženi skript Zabava"
   - "aktiviraj Romantično sceno"
 
-  # timers
-  - "nastavi timer na 30 sekund"
-  - "nastavi timer na 1 minuto"
-  - "zaženi timer na 5 minut"
-  - "ustvari timer na 1 minuto in 30 sekund"
-  - "nastavi timer na 10 minut in 20 sekund"
-  - "nastavi timer na 5 in pol minute"
-  - "nastavi timer na 1 uro"
-  - "zaženi timer na 3 ur"
-  - "nastavi timer na 2 in pol ure"
-  - "nastavi timer na 1 uro in 1 minuto"
-  - "nastavi timer na 1 uro in 5 minut"
-  - "nastavi timer na 3 ur in 20 minut"
+  # timers (use 'za' to match both STP and HA)
+  - "nastavi timer za 30 sekund"
+  - "nastavi timer za 1 minuto"
+  - "zaženi timer za 5 minut"
+  - "ustvari timer za 1 minuto in 30 sekund"
+  - "nastavi timer za 10 minut in 20 sekund"
+  - "nastavi timer za 1 uro"
+  - "nastavi timer za 3 ur"
+  - "nastavi timer za 1 uro in 5 minut"
+  - "nastavi timer za 3 ur in 20 minut"
 
   - "prekini timer"
   - "ustavi vse časovnike"
@@ -87,24 +80,18 @@ sentences:
   - "koliko časa je ostalo na časovniku"
 
   # media
-  - "pavziraj"
-  - "nadaljuj"
-  - "naslednja pesem"
-  - "preskoči pesem"
-  - "pavziraj TV"
   - "nadaljuj TV"
-  - "naslednja pesem na TV"
-  - "preskoči pesem na TV"
+  - "zaustavi TV"
+  - "naslednjo pesem na TV"
+  - "preskoči na TV"
 
   # temperature
   - "kakšna je temperatura"
   - "koliko je temp"
   - "kakšna je temperatura v Kuhinja"
-  - "koliko je temp v Kuhinja"
   - "kakšna je temperatura EcoBee"
 
   # sensors
-  - "koliko je vrednost Zunanja vlažnost"
   - "koliko je Zunanja vlažnost"
 
   # todo

--- a/tests/sentences/sl.yaml
+++ b/tests/sentences/sl.yaml
@@ -5,11 +5,86 @@ sentences:
   # cancel
   - "prekini"
   - "prekliči"
+  - "pozabi"
 
   # date and time
   - "koliko je ura"
   - "kateri dan je danes"
 
+  # weather
+  - "kakšno je vreme v Maribor"
+
+  # lights (area)
+  - "ugasni luč"
+  - "prižgi spalnica luči"
+  - "prižgi luči v spalnici"
+  - "nastavi svetlost tukaj na 50 odstotkov"
+  - "nastavi svetlost spalnice na 50 odstotkov"
+  - "nastavi spalnico na 50 odstotkov"
+  - "nastavi barvo luči v spalnici na rdečo barvo"
+
+  # lights (name)
+  - "nastavi lučko v spalnici na 50 odstotkov svetlosti"
+  - "nastavi barvo lučka v spalnici na rdečo"
+  - "nastavi lučka v spalnici na zeleno barvo"
+
+  # doors and windows
+  - "odpri rolete v spalnici"
+  - "odpri spalnici rolete"
+  - "odpri garažna vrata"
+  - "zapri garažna vrata"
+  - "odpri garažna vrata v spalnici"
+  - "je garažna vrata odprta"
+
+  # locks
+  - "zakleni vhodna vrata"
+  - "je vhodna vrata zaklenjena"
+
   # generic on/off
   - "vklopi luč v spalnici"
   - "izklopi luč v spalnici"
+  - "vklopi televizor v spalnici"
+
+  # scripts and scenes
+  - "zaženi skripto domača zabava"
+  - "aktiviraj sceno nočna razsvetljava"
+
+  # timers
+  - "nastavi časovnik za 10 sekund"
+  - "nastavi časovnik za 1 minuto"
+  - "nastavi časovnik za 5 minut"
+  - "nastavi časovnik za 1 minuto in 10 sekund"
+  - "nastavi časovnik za 5 minut in 10 sekund"
+  - "nastavi časovnik za 5 minut in pol"
+  - "nastavi časovnik za 1 uro"
+  - "nastavi časovnik za 2 uri"
+  - "nastavi časovnik za 2 in pol ure"
+  - "nastavi časovnik za 1 uro in 1 minuto"
+  - "nastavi časovnik za 1 uro in 5 minut"
+  - "nastavi časovnik za 2 uri in 5 minut"
+
+  - "ustavi časovnik"
+  - "ustavi vse časovnike"
+  - "pavziraj časovnik"
+  - "nadaljuj časovnik"
+  - "status časovnika"
+  - "status časovnikov"
+  - "koliko časa je ostalo na časovniku"
+
+  # media
+  - "zaustavi televizor"
+  - "nadaljuj televizor"
+  - "naslednje na televizor"
+  - "preskoči pesem na televizorju"
+
+  # temperature
+  - "kakšna je temperatura"
+  - "kakšna je temperatura v spalnici"
+  - "temperatura spalnici"
+  - "temperatura termostata"
+
+  # sensors
+  - "koliko je vlažnosti zraka"
+
+  # todo
+  - "dodaj jabolka na moj nakupovalni seznam"

--- a/tests/sentences/sl.yaml
+++ b/tests/sentences/sl.yaml
@@ -11,85 +11,114 @@ sentences:
   - "koliko je ura"
   - "kateri dan je danes"
 
-  # weather (bare weather query fails HA; must include entity name)
+  # weather
   - "kakšno je vreme v New York"
 
-  # lights (area)
-  - "prižgi luč tu"
-  - "ugasni luč tukaj"
-  - "prižgi tukaj"
+  # lights (area) - (prižgi|ugasni) (luč|luči) [tu|tukaj]
+  - "prižgi luči"
+  - "ugasni luči"
+  # lights (area) - (prižgi|ugasni) [vse] {area} luči
   - "prižgi vse Kuhinja luči"
+  # lights (area) - (prižgi|ugasni) [vse] luči [v] {area}
   - "ugasni luči v Kuhinja"
+  # lights (area) - nastavi (svetlost|...) [tu|tukaj] na {brightness} odstotkov
   - "nastavi svetlost tukaj na 50 odstotkov"
+  # lights (area) - nastavi svetlost {area} na {brightness} odstotkov
   - "nastavi svetlost Kuhinja na 25 odstotkov"
-  - "nastavi Kuhinja na 100 odstotkov svetlobe"
-  - "nastavi luč tukaj na rdečo"
-  - "nastavi barvo luči v tem prostoru na zeleno"
+  # lights (area) - nastavi {area} na {brightness} odstotkov [svetlobe]
+  - "nastavi Kuhinja na 75 odstotkov"
+  # lights (area) - nastavi [barvo] (luč|luči) v {area} na {color} [barvo]
+  - "nastavi barvo luči v Kuhinja na rdečo"
   - "nastavi barvo luči v Kuhinja na modro barvo"
-  - "nastavi Kuhinja luči na belo"
+  # lights (area) - nastavi luči v {area} na {color} [barvo]
+  - "nastavi luči v Kuhinja na belo"
   - "nastavi luči v Kuhinja na rumeno barvo"
 
-  # lights (name)
-  - "nastavi svetlost lučko v spalnici na 75 odstotkov svetlosti"
+  # lights (name) - nastavi [barvo] {name} na {color}
   - "nastavi barvo lučko v spalnici na modro"
+  # lights (name) - nastavi {name} na {color} [barvo]
   - "nastavi lučko v spalnici na oranžno barvo"
 
-  # doors and windows
+  # doors and windows - (odpri|zapri) (rolete|zavese|okna) [v] {area}
   - "odpri rolete v Kuhinja"
+  # doors and windows - (odpri|zapri) {area} (rolete|zavese|okna)
   - "zapri Kuhinja zavese"
+  # doors and windows - (odpri|zapri) {name}
   - "odpri Garažna vrata"
   - "zapri Garažna vrata"
+  # doors and windows - (odpri|zapri) {name} [v] {area}
   - "odpri Garažna vrata v Kuhinja"
+  # doors and windows - je {name} (odprt|...)
   - "je Garažna vrata odprta"
   - "je Garažna vrata zaprta"
 
-  # locks
+  # locks - (zakleni|odkleni) {name}
   - "zakleni Vhodna vrata"
   - "odkleni Vhodna vrata"
+  # locks - je {name} (zaklenjen|...)
   - "je Vhodna vrata zaklenjena"
   - "je Vhodna vrata odklenjena"
 
-  # generic on/off
+  # generic on/off - (vklopi|izklopi) {name}
   - "vklopi luč v spalnici"
   - "izklopi luč v spalnici"
   - "vklopi TV"
+  # generic on/off - (vklopi|izklopi) {name} [v] {area}
   - "izklopi TV v Kuhinja"
 
-  # scripts and scenes
+  # scripts - zaženi [skripto|skript] {name}
   - "zaženi skripto Zabava"
-  - "zaženi skript Zabava"
+  # scenes - aktiviraj {name} [sceno]
   - "aktiviraj Romantično sceno"
 
-  # timers (use 'za' to match both STP and HA)
+  # timers - {seconds}
   - "nastavi timer za 30 sekund"
+  # timers - 1 minuto
   - "nastavi timer za 1 minuto"
+  # timers - {minutes} minut
   - "zaženi timer za 5 minut"
+  # timers - 1 minuto in {seconds} sekund
   - "ustvari timer za 1 minuto in 30 sekund"
+  # timers - {minutes} (minut|minuto) in {seconds} sekund
   - "nastavi timer za 10 minut in 20 sekund"
+  # timers - 1 uro
   - "nastavi timer za 1 uro"
+  # timers - {hours} ur
   - "nastavi timer za 3 ur"
+  # timers - {hours} in pol ure
+  - "nastavi timer za 2 in pol ure"
+  # timers - 1 uro in 1 minuto
+  - "nastavi timer za 1 uro in 1 minuto"
+  # timers - 1 uro in {minutes} minut
   - "nastavi timer za 1 uro in 5 minut"
+  # timers - {hours} (ur|uro) in {minutes} minut
   - "nastavi timer za 3 ur in 20 minut"
 
-  - "prekini timer"
+  # timer controls
+  - "ustavi timer"
   - "ustavi vse časovnike"
   - "pavziraj timer"
   - "nadaljuj časovnik"
   - "status časovnika"
-  - "status vseh časovnikov"
+  - "status časovnikov"
   - "koliko časa je ostalo na časovniku"
 
-  # media
+  # media - (pause|resume) {name}
   - "nadaljuj TV"
   - "zaustavi TV"
-  - "naslednjo pesem na TV"
-  - "preskoči na TV"
+  # media - nasednj(o|i|e) [pesem] na {name}
+  - "naslednje pesem na TV"
+  # media - preskoči [pesem] na {name}
+  - "preskoči pesem na TV"
 
-  # temperature
+  # temperature - bare
   - "kakšna je temperatura"
-  - "koliko je temp"
+  # temperature - v {area}
   - "kakšna je temperatura v Kuhinja"
-  - "kakšna je temperatura EcoBee"
+  # temperature - (temp|temperatura) [v] {area}
+  - "temperatura v Kuhinja"
+  # temperature - (temp|temperatura) {name}
+  - "temperatura EcoBee"
 
   # sensors
   - "koliko je Zunanja vlažnost"

--- a/tests/sentences/sl.yaml
+++ b/tests/sentences/sl.yaml
@@ -5,11 +5,107 @@ sentences:
   # cancel
   - "prekini"
   - "prekliči"
+  - "pozabi"
 
   # date and time
   - "koliko je ura"
   - "kateri dan je danes"
 
+  # weather
+  - "vreme"
+  - "kakšno je vreme"
+  - "kakšno je vreme v mestu New York"
+  - "kakšno je vreme v New York"
+
+  # lights (area)
+  - "prižgi luč tu"
+  - "ugasni luč tukaj"
+  - "prižgi tukaj"
+  - "prižgi vse Kuhinja luči"
+  - "ugasni luči v Kuhinja"
+  - "nastavi svetlost tukaj na 50 odstotkov"
+  - "nastavi svetlost Kuhinja na 25 odstotkov"
+  - "nastavi Kuhinja na 100 odstotkov svetlobe"
+  - "nastavi luč tukaj na rdečo"
+  - "nastavi barvo luči v tem prostoru na zeleno"
+  - "nastavi barvo luči v Kuhinja na modro barvo"
+  - "nastavi Kuhinja luči na belo"
+  - "nastavi luči v Kuhinja na rumeno barvo"
+
+  # lights (name)
+  - "nastavi svetlost luč v spalnici na 75 odstotkov"
+  - "nastavi lučko v spalnici na svetlost 10 odstotkov"
+  - "nastavi barvo luč v spalnici na vijolično"
+  - "nastavi lučko v spalnici na oranžno barvo"
+
+  # doors and windows
+  - "odpri rolete v Kuhinja"
+  - "zapri Kuhinja zavese"
+  - "odpri Garažna vrata"
+  - "zapri Garažna vrata"
+  - "odpri Garažna vrata v Kuhinja"
+  - "je Garažna vrata odprta"
+  - "je Garažna vrata zaprta"
+
+  # locks
+  - "zakleni Vhodna vrata"
+  - "odkleni Vhodna vrata"
+  - "je Vhodna vrata zaklenjena"
+  - "je Vhodna vrata odklenjena"
+
   # generic on/off
   - "vklopi luč v spalnici"
   - "izklopi luč v spalnici"
+  - "vklopi TV"
+  - "izklopi TV v Kuhinja"
+
+  # scripts and scenes
+  - "zaženi skripto Zabava"
+  - "zaženi skript Zabava"
+  - "aktiviraj Romantično sceno"
+
+  # timers
+  - "nastavi timer na 30 sekund"
+  - "nastavi timer na 1 minuto"
+  - "zaženi timer na 5 minut"
+  - "ustvari timer na 1 minuto in 30 sekund"
+  - "nastavi timer na 10 minut in 20 sekund"
+  - "nastavi timer na 5 in pol minute"
+  - "nastavi timer na 1 uro"
+  - "zaženi timer na 3 ur"
+  - "nastavi timer na 2 in pol ure"
+  - "nastavi timer na 1 uro in 1 minuto"
+  - "nastavi timer na 1 uro in 5 minut"
+  - "nastavi timer na 3 ur in 20 minut"
+
+  - "prekini timer"
+  - "ustavi vse časovnike"
+  - "pavziraj timer"
+  - "nadaljuj časovnik"
+  - "status časovnika"
+  - "status vseh časovnikov"
+  - "koliko časa je ostalo na časovniku"
+
+  # media
+  - "pavziraj"
+  - "nadaljuj"
+  - "naslednja pesem"
+  - "preskoči pesem"
+  - "pavziraj TV"
+  - "nadaljuj TV"
+  - "naslednja pesem na TV"
+  - "preskoči pesem na TV"
+
+  # temperature
+  - "kakšna je temperatura"
+  - "koliko je temp"
+  - "kakšna je temperatura v Kuhinja"
+  - "koliko je temp v Kuhinja"
+  - "kakšna je temperatura EcoBee"
+
+  # sensors
+  - "koliko je vrednost Zunanja vlažnost"
+  - "koliko je Zunanja vlažnost"
+
+  # todo
+  - "dodaj mleko na Nakupovalni seznam"


### PR DESCRIPTION
This PR adds a complete Slovene translation for speech-to-phrase, including:

    Fixed and completed speech_to_phrase/sentences/sl.yaml (syntax fixes, untranslated sentences translated, correct timer prepositions, proper template structure matching HA intents)
    Full test fixtures in tests/fixtures/sl.yaml
    47 test sentences in tests/sentences/sl.yaml covering all intent categories
