### PR TITLE
Update Readme for TLS/SSL secured Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ docker run -it -p 10300:10300 \
   --hass-token '<LONG_LIVED_ACCESS_TOKEN>' \
   --retrain-on-start
 ```
+Note: If your Home Assistant instance uses TLS/SSL, use "wss://" for the protocol (e.g. wss://homeassistant.local:8123/api/websocket).
 
 ## Models and tools
 


### PR DESCRIPTION
Update the README file to note the different protocol required for the websocket URI if Home Assistant is using TLS/SSL.