### PR TITLE
fix(de): improve light switching sentence patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.4
+
+- Update German sentence patterns to support more variations for switching lights on/off, including support for singular "licht" and "im" (in dem) contractions. Also update test fixtures and sentences to include new test cases for the living room area.
+
 ## 1.4.3
 
 - Fix for null names

--- a/speech_to_phrase/sentences/de.yaml
+++ b/speech_to_phrase/sentences/de.yaml
@@ -42,7 +42,7 @@ data:
   # # lights (area)
   - "[alle|die] (lichter|lampen) (an|ein|aus)(schalten|machen)"
   - "(schalt|mach)[e] [alle|die] (lichter|lampen) (an|ein|aus)"
-  - "(schalt[e]|mach)[e] [alle|die|das] (lichter|lampen|licht) (in|im) [der|dem] {area} (an|ein|aus)"
+  - "(schalt|mach)[e] [alle|die|das] (lichter|lampen|licht) (in|im) [der|dem] {area} (an|ein|aus)"
   - "schalt[e] {name} (an|ein|aus)"
   - "[schalte ][das ]licht[er] [(an|ein|aus|einschalten|schalten|machen|ausschalten)]"
 

--- a/speech_to_phrase/sentences/de.yaml
+++ b/speech_to_phrase/sentences/de.yaml
@@ -42,9 +42,9 @@ data:
   # # lights (area)
   - "[alle|die] (lichter|lampen) (an|ein|aus)(schalten|machen)"
   - "(schalt|mach)[e] [alle|die] (lichter|lampen) (an|ein|aus)"
-  - "(schalt|mach)[e] [alle|die] (lichter|lampen) in [der|dem] {area} (an|ein|aus)"
+  - "(schalt[e]|mach)[e] [alle|die|das] (lichter|lampen|licht) (in|im) [der|dem] {area} (an|ein|aus)"
   - "schalt[e] {name} (an|ein|aus)"
-  - "[schalte ][ das]licht[er] [(an|ein|aus|einschalten|schalten|machen|ausschalten)]"
+  - "[schalte ][das ]licht[er] [(an|ein|aus|einschalten|schalten|machen|ausschalten)]"
 
   - "stell[e] [die] helligkeit [hier] auf {brightness} prozent"
   - "stell[e] [die] helligkeit von [der|dem] {area} auf {brightness} prozent"

--- a/tests/fixtures/de.yaml
+++ b/tests/fixtures/de.yaml
@@ -10,6 +10,7 @@ fixtures:
   areas:
     - name: "Küchen"
     - name: "Büro"
+    - name: "Wohnzimmer"
 
   entities:
     - name: "New York"

--- a/tests/sentences/de.yaml
+++ b/tests/sentences/de.yaml
@@ -23,6 +23,7 @@ sentences:
   # generic on/off
   - "schalte die Lampe an"
   - "mach die Lampe aus"
+  - "schalte das licht im wohnzimmer ein"
 
   # scripts and scenes
   - "aktiviere Batteriewarnung Skript"


### PR DESCRIPTION
Update German sentence patterns to support more variations for switching lights on/off, including support for singular "licht" and "im" (in dem) contractions. Also update test fixtures and sentences to include new test cases for the living room area.