### PR TITLE
Allow hass token and websocket URI to be set via environment variables and secret files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,42 @@ docker run -it -p 10300:10300 \
   --retrain-on-start
 ```
 
+### Environment variables and secrets
+
+`--hass-token` and `--hass-websocket-uri` can also be set from the environment, which keeps your long-lived access token out of the command line and out of `docker inspect`:
+
+| Argument | Environment variable | Secret file variable |
+| -------- | -------------------- | -------------------- |
+| `--hass-token` | `HASS_TOKEN` | `HASS_TOKEN_FILE` |
+| `--hass-websocket-uri` | `HASS_WEBSOCKET_URI` | `HASS_WEBSOCKET_URI_FILE` |
+
+The `*_FILE` variables hold a *path* to read the value from, following the convention used by [Docker secrets][docker_secrets] and Kubernetes secret volumes. Leading and trailing whitespace is stripped, so a trailing newline in the file is fine.
+
+Precedence is: command-line argument, then `*_FILE`, then the plain environment variable, then the built-in default. A `*_FILE` path that does not exist is an error rather than a silent fallback.
+
+With Docker Compose:
+
+``` yaml
+services:
+  speech-to-phrase:
+    image: rhasspy/wyoming-speech-to-phrase
+    command: ["--retrain-on-start"]
+    ports:
+      - "10300:10300"
+    volumes:
+      - ./models:/models
+      - ./train:/train
+    environment:
+      HASS_WEBSOCKET_URI: "ws://homeassistant.local:8123/api/websocket"
+      HASS_TOKEN_FILE: /run/secrets/hass_token
+    secrets:
+      - hass_token
+
+secrets:
+  hass_token:
+    file: ./hass_token.txt
+```
+
 ## Models and tools
 
 Speech models and tools are downloaded automatically from [HuggingFace](https://huggingface.co/datasets/rhasspy/rhasspy-speech/tree/main)
@@ -100,3 +136,4 @@ To make phrase recognition more robust, a "fuzzy" layer is added on top of Kaldi
 [todo]: https://www.home-assistant.io/integrations/todo
 [sentence_wildcards]: https://www.home-assistant.io/docs/automation/trigger/#sentence-wildcards
 [wyoming]: https://www.home-assistant.io/integrations/wyoming
+[docker_secrets]: https://docs.docker.com/compose/how-tos/use-secrets/

--- a/script/test_ci
+++ b/script/test_ci
@@ -17,6 +17,7 @@ _CI_TESTS = [
         "validate_yaml",
         "g2p",
         "recognize",
+        "env_default",
     )
 ]
 

--- a/speech_to_phrase/__main__.py
+++ b/speech_to_phrase/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import logging
+import os
 from functools import partial
 from pathlib import Path
 from typing import Optional
@@ -17,6 +18,24 @@ from .models import DEFAULT_MODEL, Model, get_models_for_languages
 from .train import train
 
 _LOGGER = logging.getLogger()
+
+DEFAULT_HASS_WEBSOCKET_URI = "ws://homeassistant.local:8123/api/websocket"
+
+
+def env_default(name: str) -> Optional[str]:
+    """Get an argument default from the environment.
+
+    Prefers "<NAME>_FILE", whose value is a path to read the setting from. This
+    is the convention used by Docker/Kubernetes secrets, which are exposed as
+    files rather than environment variables.
+    """
+    file_path = os.environ.get(f"{name}_FILE")
+    if file_path:
+        value = Path(file_path).read_text(encoding="utf-8").strip()
+    else:
+        value = os.environ.get(name, "").strip()
+
+    return value or None
 
 
 async def main() -> None:
@@ -38,13 +57,19 @@ async def main() -> None:
         help="Directory with custom sentence directories for each language",
     )
     # Home Assistant
+    hass_token = env_default("HASS_TOKEN")
     parser.add_argument(
-        "--hass-token", required=True, help="Long-lived access token for Home Assistant"
+        "--hass-token",
+        default=hass_token,
+        required=hass_token is None,
+        help="Long-lived access token for Home Assistant "
+        "(env: HASS_TOKEN or HASS_TOKEN_FILE)",
     )
     parser.add_argument(
         "--hass-websocket-uri",
-        default="ws://homeassistant.local:8123/api/websocket",
-        help="URI of Home Assistant websocket API",
+        default=env_default("HASS_WEBSOCKET_URI") or DEFAULT_HASS_WEBSOCKET_URI,
+        help="URI of Home Assistant websocket API "
+        "(env: HASS_WEBSOCKET_URI or HASS_WEBSOCKET_URI_FILE)",
     )
     # Training
     parser.add_argument(
@@ -77,7 +102,7 @@ async def main() -> None:
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.INFO, format=args.log_format
     )
-    _LOGGER.debug(args)
+    _LOGGER.debug({**vars(args), "hass_token": "<redacted>"})
 
     state = State(
         settings=Settings(

--- a/tests/test_env_default.py
+++ b/tests/test_env_default.py
@@ -1,0 +1,52 @@
+"""Tests for resolving argument defaults from the environment."""
+
+import pytest
+
+from speech_to_phrase.__main__ import env_default
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("TEST_SECRET", raising=False)
+    monkeypatch.delenv("TEST_SECRET_FILE", raising=False)
+
+
+def test_unset() -> None:
+    """Nothing in the environment means no default."""
+    assert env_default("TEST_SECRET") is None
+
+
+def test_from_env(monkeypatch) -> None:
+    """Value comes from the plain environment variable."""
+    monkeypatch.setenv("TEST_SECRET", "from-env")
+    assert env_default("TEST_SECRET") == "from-env"
+
+
+def test_from_file(tmp_path, monkeypatch) -> None:
+    """Value comes from the file named by <NAME>_FILE, with whitespace stripped."""
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("from-file\n", encoding="utf-8")
+    monkeypatch.setenv("TEST_SECRET_FILE", str(secret_file))
+    assert env_default("TEST_SECRET") == "from-file"
+
+
+def test_file_wins_over_env(tmp_path, monkeypatch) -> None:
+    """<NAME>_FILE takes precedence over <NAME>."""
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("from-file", encoding="utf-8")
+    monkeypatch.setenv("TEST_SECRET_FILE", str(secret_file))
+    monkeypatch.setenv("TEST_SECRET", "from-env")
+    assert env_default("TEST_SECRET") == "from-file"
+
+
+def test_empty_is_unset(monkeypatch) -> None:
+    """An empty value is treated as unset so real defaults still apply."""
+    monkeypatch.setenv("TEST_SECRET", "   ")
+    assert env_default("TEST_SECRET") is None
+
+
+def test_missing_file_is_an_error(tmp_path, monkeypatch) -> None:
+    """A <NAME>_FILE pointing nowhere fails loudly instead of starting unconfigured."""
+    monkeypatch.setenv("TEST_SECRET_FILE", str(tmp_path / "nope"))
+    with pytest.raises(FileNotFoundError):
+        env_default("TEST_SECRET")


### PR DESCRIPTION
This supersedes #102 by @baurmatt, which added plain environment variable support for the same two arguments. That PR is the right idea; this one extends it to cover secret *files*, which is what container orchestrators actually hand you, and keeps the repo's lint gate green.

## Motivation

`--hass-token` is a long-lived access token, and today the only way to supply it is on the command line. That means it shows up in `docker inspect`, in `ps`, and in shell history. Plain environment variables (#102) fix the command line but are still readable via `docker inspect` and are inherited by child processes.

[Docker secrets][docker_secrets] and Kubernetes secret volumes both expose secrets as *files*, and the widely used convention for consuming them is a `<VAR>_FILE` variable holding the path. This PR adds that.

## What changed

`--hass-token` and `--hass-websocket-uri` now resolve from, in order of precedence:

1. the command-line argument
2. `HASS_TOKEN_FILE` / `HASS_WEBSOCKET_URI_FILE` — a path to read the value from
3. `HASS_TOKEN` / `HASS_WEBSOCKET_URI`
4. the built-in default (`--hass-token` remains required if nothing supplies it)

Details worth calling out:

- Trailing whitespace is stripped, so a secret file with a trailing newline works.
- An empty or whitespace-only value is treated as unset, so the `--hass-websocket-uri` default still applies rather than the URI becoming `""`.
- A `*_FILE` path that does not exist raises `FileNotFoundError` at startup instead of silently falling back to the plain variable. Silently starting up unconfigured because a secret failed to mount is the worse failure mode.
- The token is now redacted from the `--debug` argument dump, which previously wrote it straight to the log. That rather defeats the purpose of keeping it out of the command line.

## Example

``` yaml
services:
  speech-to-phrase:
    image: rhasspy/wyoming-speech-to-phrase
    command: ["--retrain-on-start"]
    ports:
      - "10300:10300"
    volumes:
      - ./models:/models
      - ./train:/train
    environment:
      HASS_WEBSOCKET_URI: "ws://homeassistant.local:8123/api/websocket"
      HASS_TOKEN_FILE: /run/secrets/hass_token
    secrets:
      - hass_token

secrets:
  hass_token:
    file: ./hass_token.txt
```

## Tests

Added `tests/test_env_default.py` covering each precedence rule, whitespace stripping, empty-as-unset, and the missing-file error. Registered in `script/test_ci` so it runs in CI. `black`, `isort`, `flake8`, `pylint` (10.00/10) and `mypy` all pass.

Also verified end to end that `--hass-token` is still required when nothing provides it, that `HASS_TOKEN_FILE` starts the server successfully, and that the debug dump shows `'hass_token': '<redacted>'`.

README updated with a table of the variables and the compose example above.

[docker_secrets]: https://docs.docker.com/compose/how-tos/use-secrets/
